### PR TITLE
Move properties before dependencies in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,12 @@
     <groupId>org.programirame</groupId>
     <artifactId>jacoco-offline</artifactId>
     <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -22,10 +28,7 @@
             <version>0.8.0</version>
         </dependency>
     </dependencies>
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Moved the properties element before the dependencies element
in the pom file to match the standard pom layout.